### PR TITLE
Fix crash on splash screen

### DIFF
--- a/app/src/main/kotlin/org/open/smsforwarder/MainActivity.kt
+++ b/app/src/main/kotlin/org/open/smsforwarder/MainActivity.kt
@@ -24,16 +24,24 @@ class MainActivity : AppCompatActivity() {
     lateinit var navigatorHolder: NavigatorHolder
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        setUpSplashScreen()
+        super.onCreate(savedInstanceState)
+        _binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+
+    private fun setUpSplashScreen() {
         installSplashScreen().setOnExitAnimationListener { splashScreenProvider ->
             splashScreenProvider.playCustomSplashAnimation(
                 onAnimationEnded = {
                     viewModel.onInit(binding.container.childCount)
+                },
+                onError = { _ ->
+                    splashScreenProvider.remove()
+                    viewModel.onInit(binding.container.childCount)
                 }
             )
         }
-        super.onCreate(savedInstanceState)
-        _binding = ActivityMainBinding.inflate(layoutInflater)
-        setContentView(binding.root)
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/org/open/smsforwarder/extension/SplahScreenExt.kt
+++ b/app/src/main/kotlin/org/open/smsforwarder/extension/SplahScreenExt.kt
@@ -16,37 +16,41 @@ fun SplashScreenViewProvider.playCustomSplashAnimation(
     scaleAnimationDuration: Long = 1000,
     fadeoutAnimationDuration: Long = 500,
     defaultOffset: Long = 1000,
+    onError: (e: Exception) -> Unit,
     onAnimationEnded: () -> Unit
 ) {
+    try {
+        val scaleAnimation: Animation = ScaleAnimation(
+            fromX, toX,
+            fromY, toY,
+            Animation.RELATIVE_TO_SELF, pivotValue,
+            Animation.RELATIVE_TO_SELF, pivotValue
+        ).apply {
+            interpolator = AnticipateInterpolator(interpolatorTension)
+            repeatMode = Animation.REVERSE
+            repeatCount = 1
+            duration = scaleAnimationDuration
+        }
 
-    val scaleAnimation: Animation = ScaleAnimation(
-        fromX, toX,
-        fromY, toY,
-        Animation.RELATIVE_TO_SELF, pivotValue,
-        Animation.RELATIVE_TO_SELF, pivotValue
-    ).apply {
-        interpolator = AnticipateInterpolator(interpolatorTension)
-        repeatMode = Animation.REVERSE
-        repeatCount = 1
-        duration = scaleAnimationDuration
+        val fadeOutAnimation = AlphaAnimation(1f, 0f).apply {
+            startOffset = defaultOffset
+            duration = fadeoutAnimationDuration
+            setAnimationListener(object : Animation.AnimationListener {
+                override fun onAnimationStart(animation: Animation?) {}
+
+                override fun onAnimationEnd(animation: Animation?) {
+                    this@playCustomSplashAnimation.remove()
+                    onAnimationEnded.invoke()
+                }
+
+                override fun onAnimationRepeat(animation: Animation?) {}
+
+            })
+        }
+
+        this.iconView.startAnimation(scaleAnimation)
+        this.view.startAnimation(fadeOutAnimation)
+    } catch (e: Exception) {
+        onError(e)
     }
-
-    val fadeOutAnimation = AlphaAnimation(1f, 0f).apply {
-        startOffset = defaultOffset
-        duration = fadeoutAnimationDuration
-        setAnimationListener(object : Animation.AnimationListener {
-            override fun onAnimationStart(animation: Animation?) {}
-
-            override fun onAnimationEnd(animation: Animation?) {
-                this@playCustomSplashAnimation.remove()
-                onAnimationEnded.invoke()
-            }
-
-            override fun onAnimationRepeat(animation: Animation?) {}
-
-        })
-    }
-
-    this.iconView.startAnimation(scaleAnimation)
-    this.view.startAnimation(fadeOutAnimation)
 }


### PR DESCRIPTION
The issue is caused by the use of the !! operator inside Google's library for working with iconView. In certain scenarios, this view can be null, leading to a crash. Google released a fix in the alpha version of the library: [core-splashscreen 1.1.0-alpha01](https://developer.android.com/jetpack/androidx/releases/core#core-splashscreen-1.1.0-alpha01). However, using this version requires integrating an experimental SDK, which is not an ideal solution for a stable application.

![iconView !!](https://github.com/user-attachments/assets/b197c014-23b9-49f8-9b55-32ca420ba563)

As a result, it was decided to add exception handling to the playCustomSplashAnimation method. Now, in case of an error, the onError callback is invoked. If an error occurs, we remove the SplashScreenView from the view hierarchy, which prevents the crash and allows the application to continue launching.

Even after the release of a stable version of the library with the fix, the error handling will remain relevant, as it makes this part of the code more robust and secure.